### PR TITLE
refactor: update savefigs.py to use dynamic compression parameter

### DIFF
--- a/src/ebfloeseg/savefigs.py
+++ b/src/ebfloeseg/savefigs.py
@@ -23,7 +23,7 @@ def imsave(
     profile.update(
         dtype=rasterio.uint8,  # sample images are uint8; might not be needed? CP
         count=count,
-        compress="lzw",
+        compress=compress,
     )
 
     if res:


### PR DESCRIPTION
Use the `compress` variable instead of hardcoding the compression method in the `imsave` function of `savefigs.py`.