### PR TITLE
fix: don't crash when passed an already created BoundingBox object

### DIFF
--- a/src/ebfloeseg/bbox.py
+++ b/src/ebfloeseg/bbox.py
@@ -69,7 +69,10 @@ class BoundingBoxParser(click.ParamType):
         elif isinstance(value, str):
             raw_value = ast.literal_eval(value)
             value = BoundingBox(*raw_value)
-        else: 
-            msg = "%s, of type %s, can't be parsed as a BoundingBox" % (value, type(value))
+        else:
+            msg = "%s, of type %s, can't be parsed as a BoundingBox" % (
+                value,
+                type(value),
+            )
             raise NotImplementedError(msg)
         return value

--- a/src/ebfloeseg/bbox.py
+++ b/src/ebfloeseg/bbox.py
@@ -52,13 +52,14 @@ class BoundingBoxParser(click.ParamType):
             >>> BoundingBoxParser.convert("(1.2,  2.4, 3, 4)")
             BoundingBox(x1=1.2, y1=2.4, x2=3, y2=4)
 
-
             >>> BoundingBoxParser.convert("-2334051.0214676396, -414387.78951688844, -1127689.8419350237, 757861.8364224486")
             BoundingBox(x1=-2334051.0214676396, y1=-414387.78951688844, x2=-1127689.8419350237, y2=757861.8364224486)
 
+            If passed a bounding box instance, then return the same object:
             >>> BoundingBoxParser.convert(BoundingBox(-2334051, -414387, -1127689, 757861,))
             BoundingBox(x1=-2334051, y1=-414387, x2=-1127689, y2=757861)
 
+            If the method is passed something other than a string or a bounding box, it throws an error.
             >>> BoundingBoxParser.convert((1, 2, 3, 4))
             Traceback (most recent call last):
             ...
@@ -67,14 +68,14 @@ class BoundingBoxParser(click.ParamType):
 
         """
         if isinstance(value, BoundingBox):
-            pass  # the value is the correct type
+            return value
         elif isinstance(value, str):
             raw_value = ast.literal_eval(value)
             value = BoundingBox(*raw_value)
+            return value
         else:
             msg = "%s, of type %s, can't be parsed as a BoundingBox" % (
                 value,
                 type(value),
             )
             raise NotImplementedError(msg)
-        return value

--- a/src/ebfloeseg/bbox.py
+++ b/src/ebfloeseg/bbox.py
@@ -15,7 +15,7 @@ class BoundingBoxParser(click.ParamType):
     name = "X1,Y1,X2,Y2"
 
     @classmethod
-    def convert(self, value, param=None, ctx=None):
+    def convert(self, value: str | BoundingBox, param=None, ctx=None):
         """
         Examples:
             We can parse integers separated by commas:

--- a/src/ebfloeseg/bbox.py
+++ b/src/ebfloeseg/bbox.py
@@ -57,10 +57,19 @@ class BoundingBoxParser(click.ParamType):
             >>> BoundingBoxParser.convert(BoundingBox(-2334051, -414387, -1127689, 757861,))
             BoundingBox(x1=-2334051, y1=-414387, x2=-1127689, y2=757861)
 
+            >>> BoundingBoxParser.convert((1, 2, 3, 4))
+            Traceback (most recent call last):
+            ...
+            NotImplementedError: (1, 2, 3, 4), of type <class 'tuple'>, can't be parsed as a BoundingBox
+
+
         """
-        if isinstance(value, str):
+        if isinstance(value, BoundingBox):
+            pass  # the value is the correct type
+        elif isinstance(value, str):
             raw_value = ast.literal_eval(value)
             value = BoundingBox(*raw_value)
-        elif isinstance(value, BoundingBox):
-            pass
+        else: 
+            msg = "%s, of type %s, can't be parsed as a BoundingBox" % (value, type(value))
+            raise NotImplementedError(msg)
         return value

--- a/src/ebfloeseg/bbox.py
+++ b/src/ebfloeseg/bbox.py
@@ -54,11 +54,13 @@ class BoundingBoxParser(click.ParamType):
             >>> BoundingBoxParser.convert("-2334051.0214676396, -414387.78951688844, -1127689.8419350237, 757861.8364224486")
             BoundingBox(x1=-2334051.0214676396, y1=-414387.78951688844, x2=-1127689.8419350237, y2=757861.8364224486)
 
-
-
-
+            >>> BoundingBoxParser.convert(BoundingBox(-2334051, -414387, -1127689, 757861,))
+            BoundingBox(x1=-2334051, y1=-414387, x2=-1127689, y2=757861)
 
         """
-        raw_value = ast.literal_eval(value)
-        value = BoundingBox(*raw_value)
+        if isinstance(value, str):
+            raw_value = ast.literal_eval(value)
+            value = BoundingBox(*raw_value)
+        elif isinstance(value, BoundingBox):
+            pass
         return value

--- a/src/ebfloeseg/bbox.py
+++ b/src/ebfloeseg/bbox.py
@@ -17,6 +17,8 @@ class BoundingBoxParser(click.ParamType):
     @classmethod
     def convert(self, value: str | BoundingBox, param=None, ctx=None):
         """
+        Convert a string compatible with the interface for a BoundingBox into a BoundingBox instance
+
         Examples:
             We can parse integers separated by commas:
             >>> BoundingBoxParser.convert("1,2,3,4")


### PR DESCRIPTION
Update parser for bounding boxes in EBSEG to accept an existing bounding box too.

This is needed to handle the default value.