### PR TITLE
fix: add check that the image loads correctly

### DIFF
--- a/src/ebfloeseg/load.py
+++ b/src/ebfloeseg/load.py
@@ -98,6 +98,14 @@ def alpha_not_empty(img: rasterio.DatasetReader):
     alpha_c = img.read()[alpha_index]
     return np.any(alpha_c)
 
+def image_can_be_read_without_errors(img: rasterio.DatasetReader):
+    try:
+        img.read()
+        return True
+    except rasterio.RasterioIOError as e:
+        _logger.warning(e, exc_info=True)
+        return False
+
 
 LoadResult = namedtuple("LoadResult", ["content", "img"])
 
@@ -195,6 +203,7 @@ def load(
     img = rasterio.open(io.BytesIO(r.content))
 
     if validate:
+        assert image_can_be_read_without_errors(img)
         match (kind):
             case ImageType.truecolor | ImageType.cloud:
                 assert image_not_empty(img), "image is empty"

--- a/src/ebfloeseg/load.py
+++ b/src/ebfloeseg/load.py
@@ -98,6 +98,7 @@ def alpha_not_empty(img: rasterio.DatasetReader):
     alpha_c = img.read()[alpha_index]
     return np.any(alpha_c)
 
+
 def image_can_be_read_without_errors(img: rasterio.DatasetReader):
     try:
         img.read()


### PR DESCRIPTION
Sometimes the landmask images would apparently load, but not be complete:
![Screenshot 2024-11-19 at 16 20 31](https://github.com/user-attachments/assets/0577ae41-c5c7-4a1e-8537-2ad76565075d)

This wouldn't cause an error in the "landmask" step, nor would it cause an error in the Lopez code (Julia), but it would cause problems in the Buckley code because the image would fail to load correctly when calling `rasterio.DatasetReader.read()`

This PR adds a check that the image can be read properly during validation.
