### PR TITLE
make data loading based on date only, not datetime.

### DIFF
--- a/src/ebfloeseg/app.py
+++ b/src/ebfloeseg/app.py
@@ -66,7 +66,7 @@ def main(
 @app.command(help="Download an image.")
 def load(
     outfile: Annotated[Path, typer.Argument()],
-    datetime: str = ExampleDataSet.datetime,
+    date: str = ExampleDataSet.date,
     wrap: str = ExampleDataSet.wrap,
     satellite: Satellite = ExampleDataSet.satellite,
     kind: ImageType = ExampleDataSet.kind,
@@ -85,7 +85,7 @@ def load(
     _logger.debug(locals())
 
     result = load_(
-        datetime=datetime,
+        date=date,
         wrap=wrap,
         satellite=satellite,
         kind=kind,

--- a/src/ebfloeseg/load.py
+++ b/src/ebfloeseg/load.py
@@ -104,7 +104,7 @@ LoadResult = namedtuple("LoadResult", ["content", "img"])
 
 @dataclass
 class DataSet:
-    datetime: str
+    date: str
     wrap: str
     satellite: Satellite
     kind: ImageType
@@ -124,7 +124,7 @@ class DataSet:
 
 
 ExampleDataSetBeaufortSea = DataSet(
-    datetime="2016-07-01T00:00:00Z",
+    date="2016-07-01",
     wrap="day",
     satellite=Satellite.terra,
     kind=ImageType.truecolor,
@@ -141,7 +141,7 @@ ExampleDataSetBeaufortSea = DataSet(
 
 
 def load(
-    datetime: str = ExampleDataSetBeaufortSea.datetime,
+    date: str = ExampleDataSetBeaufortSea.date,
     wrap: str = ExampleDataSetBeaufortSea.wrap,
     satellite: Satellite = ExampleDataSetBeaufortSea.satellite,
     kind: ImageType = ExampleDataSetBeaufortSea.kind,
@@ -179,7 +179,7 @@ def load(
     url = f"https://wvs.earthdata.nasa.gov/api/v1/snapshot"
     payload = {
         "REQUEST": "GetSnapshot",
-        "TIME": datetime,
+        "TIME": date,
         "BBOX": f"{bbox.x1},{bbox.y1},{bbox.x2},{bbox.y2}",
         "CRS": crs,
         "LAYERS": layers,

--- a/tests/test_load.py
+++ b/tests/test_load.py
@@ -19,7 +19,7 @@ def are_equal(b1: BytesIO, p2: Path):
 
 
 ExampleDataSetBeaufortSea = DataSet(
-    datetime="2016-07-01T00:00:00Z",
+    date="2016-07-01",
     wrap="day",
     satellite=Satellite.terra,
     kind=ImageType.truecolor,


### PR DESCRIPTION
sporadically, the API seems to fail if passed an ISO8601 datetime (`YYYY-MM-DDTHH:MM:SS`) rather than a date (`YYYY-MM-DD`).

This changes the API call to pass a date rather than a datetime.

This seems to have fixed itself as of November 19. Possible no need to implement this change.